### PR TITLE
【Task6-3.各モデルの validation のテストを実装】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,7 +5,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
-
 end
 
 # == Schema Information

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,11 @@
 class Article < ApplicationRecord
+  validates :body, :title, presence: true
+  validates :body, length: { maximum: 140 }
+
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+
 end
 
 # == Schema Information

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
+  validates :body, presence: true
+
   belongs_to :user
   belongs_to :article
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,11 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
+  validates :name, presence: true
+
   has_many :articles, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
-
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class User < ApplicationRecord
   extend Devise::Models
   # Include default devise modules. Others available are:
@@ -11,6 +9,8 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end
 
 # == Schema Information

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -20,7 +20,9 @@
 #
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
+    # association :user, factory: :user
+    user
+    # association :article, factory: :article
+    article
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,11 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
-    user { nil }
+    title { "Title" }
+    body { "A" * 140 }
+    # user { nil }
+    # user { build(:user) } # 金子さんのアドバイスをもらう前の記述
+    # association :user, factory: :user # 過去動画を見た後の記述
+    user
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -22,7 +22,9 @@
 FactoryBot.define do
   factory :comment do
     body { "MyText" }
-    user { nil }
-    article { nil }
+    # association :user, factory: :user
+    user
+    # association :article, factory: :article
+    article
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
-    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}" }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
     password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
+    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
+  end
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,42 +21,36 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  describe "正常系テスト" do
   context "user と article が存在する時" do
     let(:article_like) { build(:article_like) }
     it "いいねのレコードが作成される" do
       expect(article_like).to be_valid
     end
-    end
   end
 
-  describe "異常系テスト" do
   context "user が存在しない場合" do
     let(:article_like) { build(:article_like, user: nil) }
-    it "いいねのレコードが作成されない（エラー発生）" do
+    it "いいねのレコードが作成されない" do
       expect(article_like).not_to be_valid
-
-      expect(article_like.errors.details[:user][0][:error]).to eq :blank
+      # expect(article_like.errors.details[:user][0][:error]).to eq :blank
     end
   end
 
   context "article が存在しない場合" do
     let(:article_like) { build(:article_like, article: nil) }
-    it "いいねのレコードが作成されない（エラーが発生する）" do
+    it "いいねのレコードが作成されない" do
       expect(article_like).to be_invalid
-
-      expect(article_like.errors.details[:article][0][:error]).to eq :blank
+      # expect(article_like.errors.details[:article][0][:error]).to eq :blank
     end
   end
 
   context "user と article が存在しない場合" do
     let(:article_like) { build(:article_like, user: nil, article: nil) }
-    it "いいねのレコードが作成されない（エラーが発生する）" do
+    it "いいねのレコードが作成されない" do
       expect(article_like).to be_invalid
 
-      expect(article_like.errors.details[:user][0][:error]).to eq :blank
-      expect(article_like.errors.details[:article][0][:error]).to eq :blank
+      # expect(article_like.errors.details[:user][0][:error]).to eq :blank
+      # expect(article_like.errors.details[:article][0][:error]).to eq :blank
     end
-  end
   end
 end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,5 +21,42 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系テスト" do
+  context "user と article が存在する時" do
+    let(:article_like) { build(:article_like) }
+    it "いいねのレコードが作成される" do
+      expect(article_like).to be_valid
+    end
+    end
+  end
+
+  describe "異常系テスト" do
+  context "user が存在しない場合" do
+    let(:article_like) { build(:article_like, user: nil) }
+    it "いいねのレコードが作成されない（エラー発生）" do
+      expect(article_like).not_to be_valid
+
+      expect(article_like.errors.details[:user][0][:error]).to eq :blank
+    end
+  end
+
+  context "article が存在しない場合" do
+    let(:article_like) { build(:article_like, article: nil) }
+    it "いいねのレコードが作成されない（エラーが発生する）" do
+      expect(article_like).to be_invalid
+
+      expect(article_like.errors.details[:article][0][:error]).to eq :blank
+    end
+  end
+
+  context "user と article が存在しない場合" do
+    let(:article_like) { build(:article_like, user: nil, article: nil) }
+    it "いいねのレコードが作成されない（エラーが発生する）" do
+      expect(article_like).to be_invalid
+
+      expect(article_like.errors.details[:user][0][:error]).to eq :blank
+      expect(article_like.errors.details[:article][0][:error]).to eq :blank
+    end
+  end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,54 +21,53 @@ require "rails_helper"
 
 RSpec.describe Article, type: :model do
   describe "正常系テスト" do
-  context "レコードの title,body にテキストが入力された時" do
-    # user が存在しないといけない、Userによって作られた記事だから
-    # let(:user) { build(:user) }
-    let(:article) { build(:article) } # ここから続き！let に全て帰る！
-    it "記事が投稿される" do
-      # article = user.articles.new(title: "title", body: "body")
-      # article = build(:article)
+    context "レコードの title,body にテキストが入力された時" do
+      # user が存在しないといけない、Userによって作られた記事だから
+      # let(:user) { build(:user) }
+      let(:article) { build(:article) } # ここから続き！let に全て帰る！
+      it "記事が投稿される" do
+        # article = user.articles.new(title: "title", body: "body")
+        # article = build(:article)
 
-      expect(article).to be_valid
-    end
+        expect(article).to be_valid
+      end
     end
   end
 
   describe "異常系テスト" do
-  context "レコードの body にテキストが入力されていない時" do
-    # let(:user) { build(:user) }
-    let(:article) { build(:article, body: nil)}
-    it " 記事が投稿されない（エラー発生）" do
-      # article = user.articles.new(title: "title", body: nil)
-      # article = build(:article, body: nil)
+    context "レコードの body にテキストが入力されていない時" do
+      # let(:user) { build(:user) }
+      let(:article) { build(:article, body: nil) }
+      it " 記事が投稿されない（エラー発生）" do
+        # article = user.articles.new(title: "title", body: nil)
+        # article = build(:article, body: nil)
 
-      expect(article).to be_invalid
-      expect(article.errors.details[:body][0][:error]).to eq :blank
-
+        expect(article).to be_invalid
+        # expect(article.errors.details[:body][0][:error]).to eq :blank
+      end
     end
-  end
 
-  context "レコードの body に 141文字以上入力されている時" do
-    # let(:user) { build(:user) }
-    let(:article) { build(:article, body: "A" * 141)}
-    it "記事が投稿されない（エラー発生）" do
-      # article = user.articles.new(title: "title", body: "A" * 141 )
-      # article = build(:article, body: "A"*141)
-      expect(article).to be_invalid
-      expect(article.errors.details[:body][0][:error]).to eq :too_long
-      expect(article.errors.details[:body][0][:count]).to eq 140
+    context "レコードの body に 141文字以上入力されている時" do
+      # let(:user) { build(:user) }
+      let(:article) { build(:article, body: "A" * 141) }
+      it "記事が投稿されない（エラー発生）" do
+        # article = user.articles.new(title: "title", body: "A" * 141 )
+        # article = build(:article, body: "A"*141)
+        expect(article).to be_invalid
+        # expect(article.errors.details[:body][0][:error]).to eq :too_long
+        # expect(article.errors.details[:body][0][:count]).to eq 140
+      end
     end
-  end
 
-  context "ユーザーが存在しない時" do
-    let(:article) { build(:article, user: nil) }
-    it "記事が投稿されない（エラーが発生）" do
-      # article = Article.new(title: "title", body: "body")
-      # article = build(:article, user: nil)
+    context "ユーザーが存在しない時" do
+      let(:article) { build(:article, user: nil) }
+      it "記事が投稿されない（エラーが発生）" do
+        # article = Article.new(title: "title", body: "body")
+        # article = build(:article, user: nil)
 
-      expect(article).not_to be_valid
-      expect(article.errors.details[:user][0][:error]).to eq :blank
+        expect(article).not_to be_valid
+        # expect(article.errors.details[:user][0][:error]).to eq :blank
+      end
     end
-  end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,5 +20,55 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系テスト" do
+  context "レコードの title,body にテキストが入力された時" do
+    # user が存在しないといけない、Userによって作られた記事だから
+    # let(:user) { build(:user) }
+    let(:article) { build(:article) } # ここから続き！let に全て帰る！
+    it "記事が投稿される" do
+      # article = user.articles.new(title: "title", body: "body")
+      # article = build(:article)
+
+      expect(article).to be_valid
+    end
+    end
+  end
+
+  describe "異常系テスト" do
+  context "レコードの body にテキストが入力されていない時" do
+    # let(:user) { build(:user) }
+    let(:article) { build(:article, body: nil)}
+    it " 記事が投稿されない（エラー発生）" do
+      # article = user.articles.new(title: "title", body: nil)
+      # article = build(:article, body: nil)
+
+      expect(article).to be_invalid
+      expect(article.errors.details[:body][0][:error]).to eq :blank
+
+    end
+  end
+
+  context "レコードの body に 141文字以上入力されている時" do
+    # let(:user) { build(:user) }
+    let(:article) { build(:article, body: "A" * 141)}
+    it "記事が投稿されない（エラー発生）" do
+      # article = user.articles.new(title: "title", body: "A" * 141 )
+      # article = build(:article, body: "A"*141)
+      expect(article).to be_invalid
+      expect(article.errors.details[:body][0][:error]).to eq :too_long
+      expect(article.errors.details[:body][0][:count]).to eq 140
+    end
+  end
+
+  context "ユーザーが存在しない時" do
+    let(:article) { build(:article, user: nil) }
+    it "記事が投稿されない（エラーが発生）" do
+      # article = Article.new(title: "title", body: "body")
+      # article = build(:article, user: nil)
+
+      expect(article).not_to be_valid
+      expect(article.errors.details[:user][0][:error]).to eq :blank
+    end
+  end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,34 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系テスト" do
+  context "レコードの body にコメントが入力されている時" do
+    let(:comment) { build(:comment) }
+    it "コメントが投稿される" do
+      # comment = build(:comment)
+      expect(comment).to be_valid
+    end
+  end
+  end
+
+  describe "異常系テスト" do
+  context "レコードの body にコメントが入力されていない時" do
+    let(:comment) { build(:comment, body: nil) }
+    it "コメントが投稿されない（エラーが発生する）h" do
+      # comment = build(:comment, body: nil)
+      expect(comment).not_to be_valid
+      expect(comment.errors.details[:body][0][:error]).to eq :blank
+    end
+  end
+
+  context " user と artcile が存在しない場合" do
+    let(:comment) { build(:comment, user: nil, article: nil) }
+    it "コメントが投稿されない（エラーが発生する）h" do
+      expect(comment).to be_invalid
+
+      expect(comment.errors.details[:user][0][:error]).to eq :blank
+      expect(comment.errors.details[:article][0][:error]).to eq :blank
+    end
+  end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -23,33 +23,33 @@ require "rails_helper"
 
 RSpec.describe Comment, type: :model do
   describe "正常系テスト" do
-  context "レコードの body にコメントが入力されている時" do
-    let(:comment) { build(:comment) }
-    it "コメントが投稿される" do
-      # comment = build(:comment)
-      expect(comment).to be_valid
+    context "レコードの body にコメントが入力されている時" do
+      let(:comment) { build(:comment) }
+      it "コメントが投稿される" do
+        # comment = build(:comment)
+        expect(comment).to be_valid
+      end
     end
-  end
   end
 
   describe "異常系テスト" do
-  context "レコードの body にコメントが入力されていない時" do
-    let(:comment) { build(:comment, body: nil) }
-    it "コメントが投稿されない（エラーが発生する）h" do
-      # comment = build(:comment, body: nil)
-      expect(comment).not_to be_valid
-      expect(comment.errors.details[:body][0][:error]).to eq :blank
+    context "レコードの body にコメントが入力されていない時" do
+      let(:comment) { build(:comment, body: nil) }
+      it "コメントが投稿されない（エラーが発生する）h" do
+        # comment = build(:comment, body: nil)
+        expect(comment).not_to be_valid
+        # expect(comment.errors.details[:body][0][:error]).to eq :blank
+      end
     end
-  end
 
-  context " user と artcile が存在しない場合" do
-    let(:comment) { build(:comment, user: nil, article: nil) }
-    it "コメントが投稿されない（エラーが発生する）h" do
-      expect(comment).to be_invalid
+    context " user と artcile が存在しない場合" do
+      let(:comment) { build(:comment, user: nil, article: nil) }
+      it "コメントが投稿されない（エラーが発生する）h" do
+        expect(comment).to be_invalid
 
-      expect(comment.errors.details[:user][0][:error]).to eq :blank
-      expect(comment.errors.details[:article][0][:error]).to eq :blank
+        # expect(comment.errors.details[:user][0][:error]).to eq :blank
+        # expect(comment.errors.details[:article][0][:error]).to eq :blank
+      end
     end
-  end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,49 +2,49 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe "正常系テスト" do
-  context "レコード作成に必要な情報が揃っている時(名前、メールアドレス、パスワードが入力されている場合)" do
-    let(:user) { build(:user) }
-    it "ユーザーのレコードが作成される（ユーザー登録できる）" do
-      # user = FactoryBot.build(:user)
-      # expect(user.valid?).to eq true
-      expect(user).to be_valid
+    context "レコード作成に必要な情報が揃っている時(名前、メールアドレス、パスワードが入力されている場合)" do
+      let(:user) { build(:user) }
+      it "ユーザーのレコードが作成される（ユーザー登録できる）" do
+        # user = FactoryBot.build(:user)
+        # expect(user.valid?).to eq true
+        expect(user).to be_valid
+      end
     end
-  end
   end
 
   describe "異常系テスト" do
-  context "レコードに name のみで email, password を指定していない時" do
-    let(:user) { build(:user, email: nil, password: nil) }
+    context "レコードに name のみで email, password を指定していない時" do
+      let(:user) { build(:user, email: nil, password: nil) }
 
-    it "ユーザーの作成に失敗する（エラーが発生する）" do
-      # expect(user.valid?).to eq false
-      # expect(user).not_to be_valid
-      expect(user).to be_invalid
+      it "ユーザーの作成に失敗する（エラーが発生する）" do
+        # expect(user.valid?).to eq false
+        # expect(user).not_to be_valid
+        expect(user).to be_invalid
 
-      # expect(user.errors.details[:email][0][:error]).to eq :blank
-      # expect(user.errors.details[:password][0][:error]).to eq :blank
+        # expect(user.errors.details[:email][0][:error]).to eq :blank
+        # expect(user.errors.details[:password][0][:error]).to eq :blank
+      end
     end
-  end
 
-  context "レコードに email がない場合" do
-    let(:user) { build(:user, email: nil) }
+    context "レコードに email がない場合" do
+      let(:user) { build(:user, email: nil) }
 
-    it "エラーが発生する" do
-      # expect(user.valid?).to eq false
-      expect(user).to be_invalid
+      it "エラーが発生する" do
+        # expect(user.valid?).to eq false
+        expect(user).to be_invalid
 
-      # expect(user.errors.details[:email][0][:error]).to eq :blank
+        # expect(user.errors.details[:email][0][:error]).to eq :blank
+      end
     end
-  end
 
-  context "レコードに password がない場合" do
-    let(:user) { build(:user, password: nil) }
+    context "レコードに password がない場合" do
+      let(:user) { build(:user, password: nil) }
 
-    it "エラーが発生する" do
-      # expect(user.valid?).to eq false
-      expect(user).to be_invalid
-      # expect(user.errors.details[:password][0][:error]).to eq :blank
+      it "エラーが発生する" do
+        # expect(user.valid?).to eq false
+        expect(user).to be_invalid
+        # expect(user.errors.details[:password][0][:error]).to eq :blank
+      end
     end
-  end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,48 +1,50 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  describe "正常系" do
+  describe "正常系テスト" do
   context "レコード作成に必要な情報が揃っている時(名前、メールアドレス、パスワードが入力されている場合)" do
     let(:user) { build(:user) }
-
     it "ユーザーのレコードが作成される（ユーザー登録できる）" do
       # user = FactoryBot.build(:user)
       # expect(user.valid?).to eq true
-    expect(user).to be_valid
+      expect(user).to be_valid
     end
   end
   end
 
-  describe "異常系" do
+  describe "異常系テスト" do
   context "レコードに name のみで email, password を指定していない時" do
-    let(:user) { build(:user, email: nil ,password: nil)}
+    let(:user) { build(:user, email: nil, password: nil) }
+
     it "ユーザーの作成に失敗する（エラーが発生する）" do
       # expect(user.valid?).to eq false
       # expect(user).not_to be_valid
       expect(user).to be_invalid
 
-      expect(user.errors.details[:email][0][:error]).to eq :blank
-      expect(user.errors.details[:password][0][:error]).to eq :blank
+      # expect(user.errors.details[:email][0][:error]).to eq :blank
+      # expect(user.errors.details[:password][0][:error]).to eq :blank
     end
-  end
   end
 
   context "レコードに email がない場合" do
     let(:user) { build(:user, email: nil) }
+
     it "エラーが発生する" do
       # expect(user.valid?).to eq false
       expect(user).to be_invalid
 
-      expect(user.errors.details[:email][0][:error]).to eq :blank
+      # expect(user.errors.details[:email][0][:error]).to eq :blank
     end
   end
 
   context "レコードに password がない場合" do
     let(:user) { build(:user, password: nil) }
+
     it "エラーが発生する" do
       # expect(user.valid?).to eq false
       expect(user).to be_invalid
-      expect(user.errors.details[:password][0][:error]).to eq :blank
+      # expect(user.errors.details[:password][0][:error]).to eq :blank
     end
+  end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe "正常系" do
+  context "レコード作成に必要な情報が揃っている時(名前、メールアドレス、パスワードが入力されている場合)" do
+    let(:user) { build(:user) }
+
+    it "ユーザーのレコードが作成される（ユーザー登録できる）" do
+      # user = FactoryBot.build(:user)
+      # expect(user.valid?).to eq true
+    expect(user).to be_valid
+    end
+  end
+  end
+
+  describe "異常系" do
+  context "レコードに name のみで email, password を指定していない時" do
+    let(:user) { build(:user, email: nil ,password: nil)}
+    it "ユーザーの作成に失敗する（エラーが発生する）" do
+      # expect(user.valid?).to eq false
+      # expect(user).not_to be_valid
+      expect(user).to be_invalid
+
+      expect(user.errors.details[:email][0][:error]).to eq :blank
+      expect(user.errors.details[:password][0][:error]).to eq :blank
+    end
+  end
+  end
+
+  context "レコードに email がない場合" do
+    let(:user) { build(:user, email: nil) }
+    it "エラーが発生する" do
+      # expect(user.valid?).to eq false
+      expect(user).to be_invalid
+
+      expect(user.errors.details[:email][0][:error]).to eq :blank
+    end
+  end
+
+  context "レコードに password がない場合" do
+    let(:user) { build(:user, password: nil) }
+    it "エラーが発生する" do
+      # expect(user.valid?).to eq false
+      expect(user).to be_invalid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,8 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+  end
 end


### PR DESCRIPTION
## 概要
User, Article, Comment, ArticleLike それぞれのモデルのバリデーションのテストを実装しました。

## 内容
- テストが失敗していても、最後までテストが走るように設定を変更。
- User モデルの email, password に関するバリデーションは `devise_token_auth` のデフォルトを使うこととした。