### PR TITLE
Task. 7-5 記事作成の実装【Article に関する API 実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,15 +1,25 @@
-class Api::V1::ArticlesController < ApplicationController
+class Api::V1::ArticlesController < Api::V1::BaseApiController
+  before_action :set_article, only: [:show]
+
   def index
     @articles = Article.all.order(updated_at: :desc)
     render json: @articles, each_serializer: Api::V1::ArticlePreviewSerializer # 複数は each_serializer: 、これでブラウザでJSON形式で表示させることができる
   end
 
   def show
-    @article = Article.find(params[:id])
+    # @article = Article.find(params[:id])
     render json: @article, serializer: Api::V1::ArticleSerializer
   end
 
   def create
+    # @article = Article.new(
+    #   title: params[:title],
+    #   body: params[:body],
+    #   user_id: current_user.id
+    # )
+
+    @article = current_user.articles.create!(article_params)
+    render json: @article, serializer: Api::V1::ArticleSerializer
   end
 
   def update
@@ -17,4 +27,14 @@ class Api::V1::ArticlesController < ApplicationController
 
   def destory
   end
+
+  private
+
+    def article_params
+      params.require(:article).permit(:title, :body)
+    end
+
+  # def set_article
+  #   @article = Article.find(params[:id])
+  # end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    # if @current_user.nil?
+    #   @current_user = User.first
+    # else
+    #   @current_user # 空じゃない場合
+    # end
+
+    # @current_user = @current_user || User.first
+    @current_user ||= User.first
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session # 422 エラー CSRF対策をオフにするコード
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash # 500 エラー(undefined method 'flash' for#<ActionDispatch::Request> への対処法)
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -70,12 +70,47 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
 
-  #   describe "POST /create" do
-  #     it "記事を新規作成することができる" do
-  #       get "/api/v1/articles/create"
-  #       expect(response).to have_http_status(:success)
-  #     end
-  #   end
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "ログインユーザーとして適切なパラメーターを送信した時" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+
+      # stub
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      # let(:current_user) (stub)
+
+      it "記事のレコードを作成できる" do
+        aggregate_failures "最後まで通過" do
+          expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+          res = JSON.parse(response.body)
+          expect(res["title"]).to eq params[:article][:title]
+          expect(res["body"]).to eq params[:article][:body]
+          expect(res["user"]["id"]).to eq current_user[:id]
+          expect(res["user"]["email"]).to eq current_user[:email]
+          expect(res["user"]["name"]).to eq current_user[:name]
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    # context "不適切なパラメーターを送信した時" do
+    #   let(:params) { attributes_for(:article) }
+    #   let(:current_user) { create(:user) }
+
+    #   # stub
+    #   before do
+    #     allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)
+    #   end
+    #   # let(:current_user) (stub)
+
+    #   fit "記事のレコードが作成できない" do
+    #     # binding.pry
+    #     expect(subject).to raise_error(ActionController::ParameterMissing)
+    #   end
+    # end
+  end
 
   #   describe "PATCH /update" do
   #     it "指定した任意の記事を更新することができる" do


### PR DESCRIPTION
## このプルリクエストで何をしたのか
Article 内の create メソッドに関する API 実装をしました。
base_api_controller.rb を作成し、ダミーの current_user メソッドを作成。
422 エラー CSRF対策をオフにするコードを追加。
500 エラー(undefined method 'flash' for#<ActionDispatch::Request> へ対処するコードを追加
check_yarn_integrity: を true → false に変更。
create メソッドに関するテストの実装を行いました（current_user のスタブを作成）。

## 対象issue
作業したissueのURLをここに貼ること

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
 - [x] 動作確認は実行した?
 - [x]  rubocopは実行した?

## その他参考情報